### PR TITLE
EAV-12 Data Type Support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,4 +108,4 @@ Planned work breakdown:
   - The rest of the fields are the extensive part attributes that Sierra provided. There are some redundant fields, but we don't need to populate them now.
 
 # Revised Master Plan #
-The revised master plan is located in `/home/paul/dev/protech_par/plugins/Eav/PLAN.md`
+The revised master plan is located in `/home/paul/dev/cakephp/protech_parts/plugins/Eav/PLAN.md`

--- a/config/Migrations/20251221093127_uuid_eav_setup.php
+++ b/config/Migrations/20251221093127_uuid_eav_setup.php
@@ -1,0 +1,98 @@
+<?php
+declare(strict_types=1);
+
+use Migrations\AbstractMigration;
+
+class UuidEavSetup extends AbstractMigration
+{
+    public function change(): void
+    {
+        if (!$this->hasTable('attributes')) {
+            $this->table('attributes', ['id' => false, 'primary_key' => ['id']])
+                ->addColumn('id', 'nativeuuid', ['null' => false])
+                ->addColumn('name', 'string', ['limit' => 191, 'null' => false])
+                ->addColumn('label', 'string', ['limit' => 255, 'null' => true])
+                ->addColumn('data_type', 'string', ['limit' => 50, 'null' => false])
+                ->addColumn('options', 'json', ['null' => false])
+                ->addTimestamps('created', 'modified')
+                ->addIndex(['name'], ['unique' => true, 'name' => 'idx_attributes_name'])
+                ->create();
+        }
+
+        if (!$this->hasTable('attribute_sets')) {
+            $this->table('attribute_sets', ['id' => false, 'primary_key' => ['id']])
+                ->addColumn('id', 'nativeuuid', ['null' => false])
+                ->addColumn('name', 'string', ['limit' => 191, 'null' => false])
+                ->addTimestamps('created', 'modified')
+                ->addIndex(['name'], ['unique' => true, 'name' => 'idx_attribute_sets_name'])
+                ->create();
+        }
+
+        if (!$this->hasTable('attribute_set_attributes')) {
+            $this->table('attribute_set_attributes', ['id' => false, 'primary_key' => ['attribute_set_id', 'attribute_id']])
+                ->addColumn('attribute_set_id', 'nativeuuid', ['null' => false])
+                ->addColumn('attribute_id', 'nativeuuid', ['null' => false])
+                ->addColumn('position', 'integer', ['null' => true, 'default' => 0])
+                ->addForeignKey('attribute_set_id', 'attribute_sets', 'id', ['delete' => 'CASCADE'])
+                ->addForeignKey('attribute_id', 'attributes', 'id', ['delete' => 'CASCADE'])
+                ->create();
+        }
+
+        $tables = [
+            ['table' => 'eav_string', 'valType' => 'string', 'valOptions' => array (
+  'limit' => 1024,
+)],
+            ['table' => 'eav_text', 'valType' => 'text', 'valOptions' => array (
+)],
+            ['table' => 'eav_integer', 'valType' => 'integer', 'valOptions' => array (
+)],
+            ['table' => 'eav_smallinteger', 'valType' => 'smallinteger', 'valOptions' => array (
+)],
+            ['table' => 'eav_tinyinteger', 'valType' => 'tinyinteger', 'valOptions' => array (
+)],
+            ['table' => 'eav_biginteger', 'valType' => 'biginteger', 'valOptions' => array (
+)],
+            ['table' => 'eav_decimal', 'valType' => 'decimal', 'valOptions' => array (
+  'precision' => 18,
+  'scale' => 6,
+)],
+            ['table' => 'eav_float', 'valType' => 'float', 'valOptions' => array (
+)],
+            ['table' => 'eav_boolean', 'valType' => 'boolean', 'valOptions' => array (
+)],
+            ['table' => 'eav_date', 'valType' => 'date', 'valOptions' => array (
+)],
+            ['table' => 'eav_datetime', 'valType' => 'datetime', 'valOptions' => array (
+)],
+            ['table' => 'eav_time', 'valType' => 'time', 'valOptions' => array (
+)],
+            ['table' => 'eav_json', 'valType' => 'jsonb', 'valOptions' => array (
+)],
+            ['table' => 'eav_uuid', 'valType' => 'uuid', 'valOptions' => array (
+)],
+            ['table' => 'eav_binaryuuid', 'valType' => 'binaryuuid', 'valOptions' => array (
+)],
+            ['table' => 'eav_nativeuuid', 'valType' => 'nativeuuid', 'valOptions' => array (
+)],
+            ['table' => 'eav_fk', 'valType' => 'nativeuuid', 'valOptions' => array (
+)],
+        ];
+
+        foreach ($tables as $spec) {
+            if ($this->hasTable($spec['table'])) {
+                continue;
+            }
+            $table = $this->table($spec['table'], ['id' => false, 'primary_key' => ['id']]);
+            $table
+                ->addColumn('id', 'nativeuuid', ['null' => false])
+                ->addColumn('entity_table', 'string', ['limit' => 191, 'null' => false])
+                ->addColumn('entity_id', 'nativeuuid', ['null' => false])
+                ->addColumn('attribute_id', 'nativeuuid', ['null' => false])
+                ->addColumn('value', $spec['valType'], $spec['valOptions'])
+                ->addTimestamps('created', 'modified')
+                ->addIndex(['entity_table', 'entity_id', 'attribute_id'], ['unique' => true, 'name' => 'idx_' . $spec['table'] . '_lookup'])
+                ->addForeignKey('attribute_id', 'attributes', 'id', ['delete' => 'CASCADE'])
+                ->create();
+        }
+    }
+}

--- a/src/Command/EavCreateAttributeCommand.php
+++ b/src/Command/EavCreateAttributeCommand.php
@@ -25,8 +25,7 @@ class EavCreateAttributeCommand extends Command
 
     /** @var array<string> */
     protected array $customTypes = [
-        'fk_uuid',
-        'fk_int',
+        'fk',
     ];
 
     /**
@@ -89,6 +88,9 @@ class EavCreateAttributeCommand extends Command
         $raw = strtolower(trim($type));
         if ($raw === 'jsonb') {
             $raw = 'json';
+        }
+        if ($raw === 'fk_uuid' || $raw === 'fk_int') {
+            $raw = 'fk';
         }
         $normalized = $this->typeAliases[$raw] ?? $raw;
         if (in_array($normalized, $this->customTypes, true)) {

--- a/tests/Fixture/JsonEntitiesFixture.php
+++ b/tests/Fixture/JsonEntitiesFixture.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace Eav\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class JsonEntitiesFixture extends TestFixture
+{
+    public string $table = 'json_entities';
+
+    public array $fields = [
+        'id' => ['type' => 'uuid', 'null' => false],
+        // Use jsonb so jsonb_exists(...) works without casting
+        'data' => ['type' => 'jsonb', 'null' => true],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ];
+
+    public function init(): void
+    {
+        $this->records = [
+            [
+                'id' => '33333333-3333-3333-3333-333333333331',
+                'data' => ['color' => 'red', 'size' => 'M'],
+            ],
+            [
+                'id' => '33333333-3333-3333-3333-333333333332',
+                // No "color" key to ensure it’s not counted/migrated
+                'data' => ['size' => 'L'],
+            ],
+            [
+                'id' => '33333333-3333-3333-3333-333333333333',
+                'data' => ['color' => 'blue'],
+            ],
+        ];
+        parent::init();
+    }
+}


### PR DESCRIPTION
Add UUID EAV migration, unify FK type, and improve EAV commands/tests

- Add UuidEavSetup migration to create attributes, attribute_sets, attribute_set_attributes, and eav_* value tables (native UUID primary keys and typed value columns).
- Change EavBehavior::tableFor to prefer canonical Eav table classes and fall back to a generic Cake\ORM\Table with a dynamic alias for eav_<type> tables.
- Replace custom types fk_uuid/fk_int with a single unified 'fk' type; normalize aliases and update casting behavior to respect configured pkType.
- Update EavCreateAttributeCommand, EavMigrateJsonbToEavCommand and EavSetupCommand to:
  - accept and normalize 'fk' alias,
  - allow selecting/scaffolding specific types (defaults|all|csv),
  - add --connection support for migrate command and tests,
  - use jsonb_exists(...) safely and normalize types when migrating.
- Add JsonEntitiesFixture and adjust tests to use the new fixture/table names.
- Minor docs path fix in AGENTS.md.