### PR TITLE
EAV-16 Command Connection Handling #comment What changed

### DIFF
--- a/src/Command/EavCreateAttributeCommand.php
+++ b/src/Command/EavCreateAttributeCommand.php
@@ -7,6 +7,7 @@ use Cake\Command\Command;
 use Cake\Console\Arguments;
 use Cake\Console\ConsoleIo;
 use Cake\Database\TypeFactory;
+use Cake\Datasource\ConnectionManager;
 use Cake\Utility\Inflector;
 
 class EavCreateAttributeCommand extends Command
@@ -40,12 +41,23 @@ class EavCreateAttributeCommand extends Command
         $name = (string)($args->getArgument('name') ?? '');
         $type = (string)($args->getArgument('type') ?? 'string');
         if (!$name) {
-            $io->err('Usage: bin/cake eav create_attribute name:type [--label "Label"]');
+            $io->err('Usage: bin/cake eav create_attribute name:type [--label "Label"] [--connection <name>]');
             return Command::CODE_ERROR;
         }
         if (strpos($name, ':') !== false && !$args->getArgument('type')) {
             [$name, $type] = explode(':', $name, 2);
         }
+
+        // Resolve and validate connection
+        $connectionName = (string)($args->getOption('connection') ?? 'default');
+        try {
+            ConnectionManager::get($connectionName);
+        } catch (\Throwable $e) {
+            $io->err('Unknown connection: ' . $connectionName);
+            return Command::CODE_ERROR;
+        }
+        $io->out('Using connection: ' . $connectionName);
+
         $label = (string)($args->getOption('label') ?? '');
         $normalizedType = $this->normalizeType($type, $io);
         if ($normalizedType === null) {
@@ -55,7 +67,20 @@ class EavCreateAttributeCommand extends Command
             $label = Inflector::humanize($name);
         }
 
-        $Attributes = $this->getTableLocator()->get('Eav.EavAttributes');
+        // Use the selected connection for the attributes registry; avoid reconfiguring an existing registry instance.
+        $locator = $this->getTableLocator();
+        if ($locator->exists('Eav.EavAttributes')) {
+            $Attributes = $locator->get('Eav.EavAttributes');
+            // Honor --connection: if the loaded table uses a different connection, recreate it on the requested one.
+            $actual = method_exists($Attributes->getConnection(), 'configName') ? $Attributes->getConnection()->configName() : null;
+            if ($actual !== $connectionName && method_exists($locator, 'remove')) {
+                $locator->remove('Eav.EavAttributes');
+                $Attributes = $locator->get('Eav.EavAttributes', ['connectionName' => $connectionName]);
+            }
+        } else {
+            $Attributes = $locator->get('Eav.EavAttributes', ['connectionName' => $connectionName]);
+        }
+
         $existing = $Attributes->find()->select(['id'])->where(['name' => $name])->first();
         if ($existing) {
             $io->out('Attribute already exists: ' . $name);
@@ -109,6 +134,8 @@ class EavCreateAttributeCommand extends Command
         $parser->addArgument('name', ['help' => 'Attribute name or name:type']);
         $parser->addArgument('type', ['help' => 'Attribute type', 'required' => false]);
         $parser->addOption('label', ['short' => 'l', 'help' => 'Human label']);
+        // Step 1: Add connection flag to align with other commands
+        $parser->addOption('connection', ['help' => 'Datasource connection name', 'default' => 'default']);
         return $parser;
     }
 }

--- a/tests/TestCase/Command/EavCreateAttributeCommandTest.php
+++ b/tests/TestCase/Command/EavCreateAttributeCommandTest.php
@@ -55,7 +55,8 @@ class EavCreateAttributeCommandTest extends TestCase
 
     public function testCreateAttribute(): void
     {
-        $this->exec('eav create_attribute color:string -l "Color"');
+        // Pass explicit test connection to ensure writes land on the test datasource
+        $this->exec('eav create_attribute color:string -l "Color" --connection test');
         $this->assertExitSuccess();
         $this->assertOutputContains('Created attribute color (string)');
 
@@ -68,10 +69,10 @@ class EavCreateAttributeCommandTest extends TestCase
 
     public function testDuplicateAttributeNoop(): void
     {
-        $this->exec('eav create_attribute color:string -l "Color"');
+        $this->exec('eav create_attribute color:string -l "Color" --connection test');
         $this->assertExitSuccess();
 
-        $this->exec('eav create_attribute color:string -l "Color"');
+        $this->exec('eav create_attribute color:string -l "Color" --connection test');
         $this->assertExitSuccess();
         $this->assertOutputContains('Attribute already exists: color');
 


### PR DESCRIPTION
                                            - Create Attribute command now honors --connection, validates the datasource, and uses the requested connection when loading the EAV registry:
                                              - Added --connection option in [plugins/Eav/src/Command/EavCreateAttributeCommand.php](file:///home/paul/dev/cakephp/protech_parts/plugins/Eav/src/Command/EavCreateAttributeCommand.php).
                                              - Validates the provided connection via ConnectionManager before proceeding. - Uses TableLocator with ['connectionName' => <name>] and avoids reconfiguration errors by:
                                                - Reusing an existing Eav.EavAttributes table instance when already registered.
                                                - Removing and reloading the table on the requested connection only if the loaded one differs. - Prints “Using connection: <name>” for visibility in interactive runs.

                                            Why this change
                                            - Fixes multi-connection support for the Create Attribute path, aligning it with Setup and JSONB Migrator commands, and prevents “already exists in the registry” errors in tests or long-running CLI sessions.

                                            Goals met
                                            - Ensure CLI commands work across multiple connections with minimal flags: Yes.
                                            - Provide consistent behavior with connection selection (interactive vs non-interactive):
                                              - Non-interactive Create Attribute now supports --connection; Setup wizard already prompts when needed. - Maintain driver guards where applicable: No changes required for this command (guards remain in other commands).

                                            Acceptance criteria met
                                            - All commands that touch the database honor an explicit --connection flag or derive via wizard: Yes.
                                              - Setup (non-interactive) respects --connection; wizard prompts.
                                              - JSONB migrator already honors --connection. - Create Attribute now honors --connection and writes to the intended datasource. - Postgres-only feature guards remain intact (unchanged for this feature). - Create Attribute writes to the selected datasource as verified by tests.

                                            Files changed
                                            - Modified
                                              - [plugins/Eav/src/Command/EavCreateAttributeCommand.php](file:///home/paul/dev/cakephp/protech_parts/plugins/Eav/src/Command/EavCreateAttributeCommand.php)

                                            Tests added/updated
                                            - Updated
                                              - [plugins/Eav/tests/TestCase/Command/EavCreateAttributeCommandTest.php](file:///home/paul/dev/cakephp/protech_parts/plugins/Eav/tests/TestCase/Command/EavCreateAttributeCommandTest.php)
                                                - Passes --connection test to ensure writes land on the test datasource.
                                                - Covers duplicate no-op behavior under the same connection.