### PR TITLE
EAV-24 Create Attribute UX Consistency

### DIFF
--- a/src/Command/EavCreateAttributeCommand.php
+++ b/src/Command/EavCreateAttributeCommand.php
@@ -31,20 +31,28 @@ class EavCreateAttributeCommand extends Command
     /**
      * Create an attribute.
      *
+     * Flags-only UX:
+     *   bin/cake eav create_attribute --name <name> --type <type> [--connection <name>]
+     *
      * @param \Cake\Console\Arguments $args Arguments.
      * @param \Cake\Console\ConsoleIo $io Console io.
      * @return int
      */
     public function execute(Arguments $args, ConsoleIo $io): int
     {
-        $name = (string)($args->getArgument('name') ?? '');
-        $type = (string)($args->getArgument('type') ?? 'string');
-        if (!$name) {
-            $io->err('Usage: bin/cake eav create_attribute name:type [--connection <name>]');
+        // Enforce flags-only input
+        $name = (string)($args->getOption('name') ?? '');
+        $type = (string)($args->getOption('type') ?? '');
+
+        if ($name === '') {
+            $io->err('Missing required option: --name');
+            $io->err('Usage: bin/cake eav create_attribute --name <name> --type <type> [--connection <name>]');
             return Command::CODE_ERROR;
         }
-        if (strpos($name, ':') !== false && !$args->getArgument('type')) {
-            [$name, $type] = explode(':', $name, 2);
+        if ($type === '') {
+            $io->err('Missing required option: --type');
+            $io->err('Usage: bin/cake eav create_attribute --name <name> --type <type> [--connection <name>]');
+            return Command::CODE_ERROR;
         }
 
         // Resolve and validate connection
@@ -124,10 +132,23 @@ class EavCreateAttributeCommand extends Command
 
     public function buildOptionParser(\Cake\Console\ConsoleOptionParser $parser): \Cake\Console\ConsoleOptionParser
     {
-        $parser->addArgument('name', ['help' => 'Attribute name or name:type']);
-        $parser->addArgument('type', ['help' => 'Attribute type', 'required' => false]);
-        // Step 1: Add connection flag to align with other commands
-        $parser->addOption('connection', ['help' => 'Datasource connection name', 'default' => 'default']);
+        // Flags-only parser (no positional arguments)
+        $parser
+            ->setDescription('Create an EAV attribute in the eav_attributes registry.')
+            ->addOption('name', [
+                'help' => 'Attribute name (e.g., color)',
+                'short' => 'n',
+            ])
+            ->addOption('type', [
+                'help' => 'Attribute type (e.g., string, integer, json, fk)',
+                'short' => 't',
+            ])
+            ->addOption('connection', [
+                'help' => 'Datasource connection name',
+                'default' => 'default',
+            ])
+            ->setEpilog('Example: bin/cake eav create_attribute --name color --type string --connection test');
+
         return $parser;
     }
 }

--- a/tests/TestCase/Command/EavCreateAttributeCommandTest.php
+++ b/tests/TestCase/Command/EavCreateAttributeCommandTest.php
@@ -56,7 +56,7 @@ class EavCreateAttributeCommandTest extends TestCase
     public function testCreateAttribute(): void
     {
         // Pass explicit test connection to ensure writes land on the test datasource
-        $this->exec('eav create_attribute color:string --connection test');
+        $this->exec('eav create_attribute --name color --type string --connection test');
         $this->assertExitSuccess();
         $this->assertOutputContains('Created attribute color (string)');
 
@@ -67,15 +67,29 @@ class EavCreateAttributeCommandTest extends TestCase
 
     public function testDuplicateAttributeNoop(): void
     {
-        $this->exec('eav create_attribute color:string --connection test');
+        $this->exec('eav create_attribute --name color --type string --connection test');
         $this->assertExitSuccess();
 
-        $this->exec('eav create_attribute color:string --connection test');
+        $this->exec('eav create_attribute --name color --type string --connection test');
         $this->assertExitSuccess();
         $this->assertOutputContains('Attribute already exists: color');
 
         $Attributes = TableRegistry::getTableLocator()->get('Eav.EavAttributes');
         $count = $Attributes->find()->where(['name' => 'color'])->count();
         $this->assertSame(1, $count);
+    }
+
+    public function testMissingNameShowsError(): void
+    {
+        $this->exec('eav create_attribute --type string --connection test');
+        $this->assertExitError();
+        $this->assertErrorContains('Missing required option: --name');
+    }
+
+    public function testMissingTypeShowsError(): void
+    {
+        $this->exec('eav create_attribute --name color --connection test');
+        $this->assertExitError();
+        $this->assertErrorContains('Missing required option: --type');
     }
 }


### PR DESCRIPTION
Flags-only UX enforced:
The command reads only --name and --type and validates both with clear errors and non-zero exit. See file://plugins/Eav/src/Command/EavCreateAttributeCommand.php#execute and file://plugins/Eav/src/Command/EavCreateAttributeCommand.php#buildOptionParser. name:type parsing and --label are gone from the command and help text. Connection handling is preserved:
--connection is accepted, validated via ConnectionManager, and used to load the [Eav.EavAttributes] table on that connection. See file://plugins/Eav/src/Command/EavCreateAttributeCommand.php#execute. Type normalization unchanged:
Aliases (jsonb->json, fk_uuid/fk_int->fk) preserved; validation remains consistent with prior behavior. See file://plugins/Eav/src/Command/EavCreateAttributeCommand.php#normalizeType. Tests reflect the new UX and pass the acceptance:
Happy path: eav create_attribute --name color --type string --connection test creates the attribute and confirms normalized type. See file://plugins/Eav/tests/TestCase/Command/EavCreateAttributeCommandTest.php#testCreateAttribute. Duplicate: prints “Attribute already exists: color” with success exit. See file://plugins/Eav/tests/TestCase/Command/EavCreateAttributeCommandTest.php#testDuplicateAttributeNoop. Negatives: missing --name and missing --type emit specific errors with non-zero exit. See file://plugins/Eav/tests/TestCase/Command/EavCreateAttributeCommandTest.php#testMissingNameShowsError and file://plugins/Eav/tests/TestCase/Command/EavCreateAttributeCommandTest.php#testMissingTypeShowsError. No JSON Storage options are surfaced anywhere in the command or tests.