### PR TITLE
EAV-28 Value Table Entity Reference 

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -559,7 +559,7 @@ Outputs
 
 Schema specifics for all eav_* tables (unchanged)
 - id: UUID (row id via chosen uuidType)
-- entity_table: string(191)
+- entity_table: string(255)
 - entity_id: uuidType or biginteger based on PK family
 - attribute_id: UUID
 - value: per eav_<type> (json/jsonb for eav_json), NULL allowed
@@ -725,8 +725,8 @@ Goals
   - EavEntities acts as an entity registry; values continue to live in eav_* typed tables or JSON Storage Mode per table (the Behavior provides access).
 - Validation and behaviors:
   - Add Timestamp behavior across all models.
-  - EavAttributes: name required/unique (<=191), data_type required (validated against TypeFactory/custom).
-  - EavAttributeSets: name required/unique (<=191).
+  - EavAttributes: name required/unique (<=255), data_type required (validated against TypeFactory/custom).
+  - EavAttributeSets: name required/unique (<=255).
   - EavAttributeSetAttributes: composite PK (attribute_set_id, attribute_id), position integer >= 0 (nullable, default 0).
   - EavEntities: name required/unique; optional model_alias/table_name; storage_default enum (tables|json_column); optional json_column; pk_type (uuid|int), uuid_subtype (uuid|binaryuuid|nativeuuid).
 

--- a/src/Command/EavSetupCommand.php
+++ b/src/Command/EavSetupCommand.php
@@ -471,7 +471,7 @@ class {$className} extends BaseMigration
         if (!\$this->hasTable('eav_attributes')) {
             \$this->table('eav_attributes', ['id' => false, 'primary_key' => ['id']])
                 ->addColumn('id', '{$uuidType}', ['null' => false])
-                ->addColumn('name', 'string', ['limit' => 191, 'null' => false])
+                ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
                 ->addColumn('data_type', 'string', ['limit' => 50, 'null' => false])
                 ->addColumn('placeholder', 'string', ['limit' => 255, 'null' => true])
                 ->addColumn('help_text', 'string', ['limit' => 255, 'null' => true])
@@ -483,7 +483,7 @@ class {$className} extends BaseMigration
         if (!\$this->hasTable('eav_attribute_sets')) {
             \$this->table('eav_attribute_sets', ['id' => false, 'primary_key' => ['id']])
                 ->addColumn('id', '{$uuidType}', ['null' => false])
-                ->addColumn('name', 'string', ['limit' => 191, 'null' => false])
+                ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
                 ->addTimestamps('created', 'modified')
                 ->addIndex(['name'], ['unique' => true, 'name' => 'idx_eav_attribute_sets_name'])
                 ->create();
@@ -493,11 +493,11 @@ class {$className} extends BaseMigration
         if (!\$this->hasTable('eav_entities')) {
             \$this->table('eav_entities', ['id' => false, 'primary_key' => ['id']])
                 ->addColumn('id', '{$uuidType}', ['null' => false])
-                ->addColumn('name', 'string', ['limit' => 191, 'null' => false])
-                ->addColumn('model_alias', 'string', ['limit' => 191, 'null' => true])
-                ->addColumn('table_name', 'string', ['limit' => 191, 'null' => true])
+                ->addColumn('name', 'string', ['limit' => 255, 'null' => false])
+                ->addColumn('model_alias', 'string', ['limit' => 255, 'null' => true])
+                ->addColumn('table_name', 'string', ['limit' => 255, 'null' => true])
                 ->addColumn('storage_default', 'string', ['limit' => 20, 'null' => false, 'default' => 'tables'])
-                ->addColumn('json_column', 'string', ['limit' => 191, 'null' => true])
+                ->addColumn('json_column', 'string', ['limit' => 255, 'null' => true])
                 ->addColumn('pk_type', 'string', ['limit' => 10, 'null' => false, 'default' => 'uuid'])
                 ->addColumn('uuid_subtype', 'string', ['limit' => 20, 'null' => true])
                 ->addTimestamps('created', 'modified')
@@ -526,13 +526,14 @@ class {$className} extends BaseMigration
             \$table = \$this->table(\$spec['table'], ['id' => false, 'primary_key' => ['id']]);
             \$table
                 ->addColumn('id', '{$uuidType}', ['null' => false])
-                ->addColumn('entity_table', 'string', ['limit' => 191, 'null' => false])
+                ->addColumn('eav_entity_id', '{$uuidType}', ['null' => false])
                 ->addColumn('{$entityField}', '{$entityFieldType}', ['null' => false])
-                ->addColumn('attribute_id', '{$uuidType}', ['null' => false])
+                ->addColumn('eav_attribute_id', '{$uuidType}', ['null' => false])
                 ->addColumn('value', \$spec['valType'], array_merge(\$spec['valOptions'], ['null' => true]))
                 ->addTimestamps('created', 'modified')
-                ->addIndex(['entity_table', '{$entityField}', 'attribute_id'], ['unique' => true, 'name' => 'idx_' . \$spec['table'] . '_lookup'])
-                ->addForeignKey('attribute_id', 'eav_attributes', 'id', ['delete' => 'CASCADE'])
+                ->addIndex(['eav_entity_id', '{$entityField}', 'eav_attribute_id'], ['unique' => true, 'name' => 'idx_' . \$spec['table'] . '_lookup'])
+                ->addForeignKey('eav_entity_id', 'eav_entities', 'id', ['delete' => 'CASCADE'])
+                ->addForeignKey('eav_attribute_id', 'eav_attributes', 'id', ['delete' => 'CASCADE'])
                 ->create();
         }
     }
@@ -630,7 +631,7 @@ PHP;
         $mapEntityId = function (string $pkType, string $uuidType) use ($mapUuidCol): string {
             return $pkType === 'int' ? 'BIGINT' : $mapUuidCol($uuidType);
         };
-        $mapVarchar = function (int $len = 191) use ($isPg): string {
+        $mapVarchar = function (int $len = 255) use ($isPg): string {
             return 'VARCHAR(' . $len . ')';
         };
         $mapTimestamp = function () use ($isPg, $isMy): string {
@@ -670,17 +671,17 @@ PHP;
             $lines = [];
             $lines[] = "CREATE TABLE IF NOT EXISTS {$table} (";
             $lines[] = "  id {$idCol} NOT NULL,";
-            $lines[] = "  entity_table " . $mapVarchar(191) . " NOT NULL,";
+            $lines[] = "  eav_entity_id {$idCol} NOT NULL,";
             $lines[] = "  entity_id {$entityIdCol} NOT NULL,";
-            $lines[] = "  attribute_id {$idCol} NOT NULL,";
+            $lines[] = "  eav_attribute_id {$idCol} NOT NULL,";
             $lines[] = "  value {$valueType} NULL,";
             $lines[] = "  created {$tsCol} DEFAULT CURRENT_TIMESTAMP,";
             $lines[] = "  modified {$tsCol} DEFAULT CURRENT_TIMESTAMP,";
             $lines[] = "  PRIMARY KEY (id)";
             $lines[] = ");";
-            $lines[] = "CREATE UNIQUE INDEX IF NOT EXISTS idx_{$table}_lookup ON {$table} (entity_table, entity_id, attribute_id);";
-            // PG add FK with ON DELETE CASCADE; MySQL can do the same
-            $lines[] = "ALTER TABLE {$table} ADD CONSTRAINT fk_{$table}_attribute_id FOREIGN KEY (attribute_id) REFERENCES eav_attributes(id) ON DELETE CASCADE;";
+            $lines[] = "CREATE UNIQUE INDEX IF NOT EXISTS idx_{$table}_lookup ON {$table} (eav_entity_id, entity_id, eav_attribute_id);";
+            $lines[] = "ALTER TABLE {$table} ADD CONSTRAINT fk_{$table}_eav_entity_id FOREIGN KEY (eav_entity_id) REFERENCES eav_entities(id) ON DELETE CASCADE;";
+            $lines[] = "ALTER TABLE {$table} ADD CONSTRAINT fk_{$table}_eav_attribute_id FOREIGN KEY (eav_attribute_id) REFERENCES eav_attributes(id) ON DELETE CASCADE;";
             return implode("\n", $lines) . "\n";
         };
 
@@ -689,7 +690,7 @@ PHP;
         $ddl[] = "-- Core attribute registry tables";
         $ddl[] = "CREATE TABLE IF NOT EXISTS eav_attributes (";
         $ddl[] = "  id {$idCol} NOT NULL,";
-        $ddl[] = "  name " . $mapVarchar(191) . " NOT NULL,";
+        $ddl[] = "  name " . $mapVarchar(255) . " NOT NULL,";
         $ddl[] = "  data_type " . $mapVarchar(50) . " NOT NULL,";
         $ddl[] = "  placeholder " . $mapVarchar(255) . " NULL,";
         $ddl[] = "  help_text " . $mapVarchar(255) . " NULL,";
@@ -702,7 +703,7 @@ PHP;
 
         $ddl[] = "CREATE TABLE IF NOT EXISTS eav_attribute_sets (";
         $ddl[] = "  id {$idCol} NOT NULL,";
-        $ddl[] = "  name " . $mapVarchar(191) . " NOT NULL,";
+        $ddl[] = "  name " . $mapVarchar(255) . " NOT NULL,";
         $ddl[] = "  created {$tsCol} DEFAULT CURRENT_TIMESTAMP,";
         $ddl[] = "  modified {$tsCol} DEFAULT CURRENT_TIMESTAMP,";
         $ddl[] = "  PRIMARY KEY (id)";
@@ -713,11 +714,11 @@ PHP;
         // New: eav_entities registry table
         $ddl[] = "CREATE TABLE IF NOT EXISTS eav_entities (";
         $ddl[] = "  id {$idCol} NOT NULL,";
-        $ddl[] = "  name " . $mapVarchar(191) . " NOT NULL,";
-        $ddl[] = "  model_alias " . $mapVarchar(191) . " NULL,";
-        $ddl[] = "  table_name " . $mapVarchar(191) . " NULL,";
+        $ddl[] = "  name " . $mapVarchar(255) . " NOT NULL,";
+        $ddl[] = "  model_alias " . $mapVarchar(255) . " NULL,";
+        $ddl[] = "  table_name " . $mapVarchar(255) . " NULL,";
         $ddl[] = "  storage_default " . $mapVarchar(20) . " NOT NULL,";
-        $ddl[] = "  json_column " . $mapVarchar(191) . " NULL,";
+        $ddl[] = "  json_column " . $mapVarchar(255) . " NULL,";
         $ddl[] = "  pk_type " . $mapVarchar(10) . " NOT NULL,";
         $ddl[] = "  uuid_subtype " . $mapVarchar(20) . " NULL,";
         $ddl[] = "  created {$tsCol} DEFAULT CURRENT_TIMESTAMP,";

--- a/src/Model/Table/EavAttributeSetsTable.php
+++ b/src/Model/Table/EavAttributeSetsTable.php
@@ -67,7 +67,7 @@ class EavAttributeSetsTable extends Table
     {
         $validator
             ->scalar('name')
-            ->maxLength('name', 191)
+            ->maxLength('name', 255)
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);

--- a/src/Model/Table/EavAttributesTable.php
+++ b/src/Model/Table/EavAttributesTable.php
@@ -66,7 +66,7 @@ class EavAttributesTable extends Table
 
         $validator
             ->scalar('name')
-            ->maxLength('name', 191)
+            ->maxLength('name', 255)
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);

--- a/src/Model/Table/EavEntitiesTable.php
+++ b/src/Model/Table/EavEntitiesTable.php
@@ -56,19 +56,19 @@ class EavEntitiesTable extends Table
     {
         $validator
             ->scalar('name')
-            ->maxLength('name', 191)
+            ->maxLength('name', 255)
             ->requirePresence('name', 'create')
             ->notEmptyString('name')
             ->add('name', 'unique', ['rule' => 'validateUnique', 'provider' => 'table']);
 
         $validator
             ->scalar('model_alias')
-            ->maxLength('model_alias', 191)
+            ->maxLength('model_alias', 255)
             ->allowEmptyString('model_alias');
 
         $validator
             ->scalar('table_name')
-            ->maxLength('table_name', 191)
+            ->maxLength('table_name', 255)
             ->allowEmptyString('table_name');
 
         $validator
@@ -78,7 +78,7 @@ class EavEntitiesTable extends Table
 
         $validator
             ->scalar('json_column')
-            ->maxLength('json_column', 191)
+            ->maxLength('json_column', 255)
             ->allowEmptyString('json_column');
 
         $validator

--- a/tests/Fixture/AttributeSetsFixture.php
+++ b/tests/Fixture/AttributeSetsFixture.php
@@ -11,7 +11,7 @@ class AttributeSetsFixture extends TestFixture
 
     public array $fields = [
         'id' => ['type' => 'uuid', 'null' => false],
-        'name' => ['type' => 'string', 'length' => 191, 'null' => false],
+        'name' => ['type' => 'string', 'length' => 255, 'null' => false],
         'created' => ['type' => 'datetime', 'null' => false],
         'modified' => ['type' => 'datetime', 'null' => false],
         '_constraints' => [

--- a/tests/Fixture/EavAttributesFixture.php
+++ b/tests/Fixture/EavAttributesFixture.php
@@ -27,7 +27,7 @@ class EavAttributesFixture extends TestFixture
      */
     public array $fields = [
         'id' => ['type' => 'uuid', 'null' => false],
-        'name' => ['type' => 'string', 'length' => 191, 'null' => false],
+        'name' => ['type' => 'string', 'length' => 255, 'null' => false],
         'data_type' => ['type' => 'string', 'length' => 50, 'null' => false],
         'placeholder' => ['type' => 'string', 'length' => 255, 'null' => true],
         'help_text' => ['type' => 'string', 'length' => 255, 'null' => true],

--- a/tests/Fixture/EavJsonFixture.php
+++ b/tests/Fixture/EavJsonFixture.php
@@ -11,7 +11,7 @@ class EavJsonFixture extends TestFixture
 
     public array $fields = [
         'id' => ['type' => 'uuid', 'null' => false],
-        'entity_table' => ['type' => 'string', 'length' => 191, 'null' => false],
+        'entity_table' => ['type' => 'string', 'length' => 255, 'null' => false],
         'entity_id' => ['type' => 'uuid', 'null' => false],
         'attribute_id' => ['type' => 'uuid', 'null' => false],
         'value' => ['type' => 'json', 'null' => true],

--- a/tests/Fixture/EavStringFixture.php
+++ b/tests/Fixture/EavStringFixture.php
@@ -11,7 +11,7 @@ class EavStringFixture extends TestFixture
 
     public array $fields = [
         'id' => ['type' => 'uuid', 'null' => false],
-        'entity_table' => ['type' => 'string', 'length' => 191, 'null' => false],
+        'entity_table' => ['type' => 'string', 'length' => 255, 'null' => false],
         'entity_id' => ['type' => 'uuid', 'null' => false],
         'attribute_id' => ['type' => 'uuid', 'null' => false],
         'value' => ['type' => 'string', 'length' => 1024, 'null' => true],

--- a/tests/TestCase/Command/EavCreateAttributeCommandTest.php
+++ b/tests/TestCase/Command/EavCreateAttributeCommandTest.php
@@ -30,7 +30,7 @@ class EavCreateAttributeCommandTest extends TestCase
             $schema = new TableSchema('eav_attributes');
             $schema
                 ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('name', ['type' => 'string', 'length' => 191, 'null' => false])
+                ->addColumn('name', ['type' => 'string', 'length' => 255, 'null' => false])
                 ->addColumn('data_type', ['type' => 'string', 'length' => 50, 'null' => false])
                 ->addColumn('placeholder', ['type' => 'string', 'length' => 255, 'null' => true])
                 ->addColumn('help_text', ['type' => 'string', 'length' => 255, 'null' => true])

--- a/tests/TestCase/Command/EavMigrateJsonbToEavCommandTest.php
+++ b/tests/TestCase/Command/EavMigrateJsonbToEavCommandTest.php
@@ -44,7 +44,7 @@ class EavMigrateJsonbToEavCommandTest extends TestCase
             $schema = new TableSchema('eav_attributes');
             $schema
                 ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('name', ['type' => 'string', 'length' => 191, 'null' => false])
+                ->addColumn('name', ['type' => 'string', 'length' => 255, 'null' => false])
                 ->addColumn('data_type', ['type' => 'string', 'length' => 50, 'null' => false])
                 ->addColumn('placeholder', ['type' => 'string', 'length' => 255, 'null' => true])
                 ->addColumn('help_text', ['type' => 'string', 'length' => 255, 'null' => true])
@@ -58,7 +58,7 @@ class EavMigrateJsonbToEavCommandTest extends TestCase
             $schema = new TableSchema('eav_string');
             $schema
                 ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('entity_table', ['type' => 'string', 'length' => 191, 'null' => false])
+                ->addColumn('entity_table', ['type' => 'string', 'length' => 255, 'null' => false])
                 ->addColumn('entity_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('attribute_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('value', ['type' => 'string', 'length' => 1024, 'null' => true])

--- a/tests/TestCase/Command/EavSetupCommandTest.php
+++ b/tests/TestCase/Command/EavSetupCommandTest.php
@@ -29,6 +29,14 @@ class EavSetupCommandTest extends TestCase
         $this->assertOutputContains("->addTimestamps('created', 'modified')");
         $this->assertOutputContains("->addColumn('placeholder'");
         $this->assertOutputContains("->addColumn('help_text'");
+
+        // EAV-28: updated value tables schema
+        $this->assertOutputContains("->addColumn('eav_entity_id'");
+        $this->assertOutputContains("->addColumn('eav_attribute_id'");
+        $this->assertOutputContains("->addForeignKey('eav_entity_id', 'eav_entities', 'id'");
+        $this->assertOutputContains("->addForeignKey('eav_attribute_id', 'eav_attributes', 'id'");
+        $this->assertOutputContains("->addIndex(['eav_entity_id', 'entity_id', 'eav_attribute_id']");
+        $this->assertOutputNotContains("->addColumn('entity_table'");
     }
 
     public function testRawSqlDryRunOnSupportedDrivers(): void
@@ -49,13 +57,21 @@ class EavSetupCommandTest extends TestCase
         $this->assertOutputContains('Dry run - SQL not written.');
         $this->assertOutputContains('EAV Setup SQL');
         $this->assertOutputContains('CREATE TABLE IF NOT EXISTS eav_attributes');
-                $this->assertOutputContains('placeholder');
+        $this->assertOutputContains('placeholder');
         $this->assertOutputContains('help_text');
 
         $this->assertOutputContains('CREATE TABLE IF NOT EXISTS eav_attribute_sets');
         $this->assertOutputContains('CREATE TABLE IF NOT EXISTS eav_entities');
         $this->assertOutputContains('CREATE TABLE IF NOT EXISTS eav_attribute_sets_eav_attributes');
+
+        // EAV-28: value tables DDL checks
         $this->assertOutputContains('CREATE UNIQUE INDEX IF NOT EXISTS idx_eav_string_lookup');
+        $this->assertOutputContains('(eav_entity_id, entity_id, eav_attribute_id)');
+        $this->assertOutputContains('FOREIGN KEY (eav_entity_id) REFERENCES eav_entities(id)');
+        $this->assertOutputContains('FOREIGN KEY (eav_attribute_id) REFERENCES eav_attributes(id)');
+        $this->assertOutputContains('eav_entity_id');
+        $this->assertOutputContains('eav_attribute_id');
+        $this->assertOutputNotContains('entity_table');
     }
 
     public function testConfigFileRespectedForOutputModeAndTypes(): void

--- a/tests/TestCase/Model/Behavior/EavBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EavBehaviorTest.php
@@ -56,7 +56,7 @@ class EavBehaviorTest extends TestCase
             $schema = new TableSchema('eav_attributes');
             $schema
                 ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('name', ['type' => 'string', 'length' => 191, 'null' => false])
+                ->addColumn('name', ['type' => 'string', 'length' => 255, 'null' => false])
                 ->addColumn('data_type', ['type' => 'string', 'length' => 50, 'null' => false])
                 ->addColumn('placeholder', ['type' => 'string', 'length' => 255, 'null' => true])
                 ->addColumn('help_text', ['type' => 'string', 'length' => 255, 'null' => true])
@@ -70,7 +70,7 @@ class EavBehaviorTest extends TestCase
             $schema = new TableSchema('eav_string');
             $schema
                 ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('entity_table', ['type' => 'string', 'length' => 191, 'null' => false])
+                ->addColumn('entity_table', ['type' => 'string', 'length' => 255, 'null' => false])
                 ->addColumn('entity_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('attribute_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('value', ['type' => 'string', 'length' => 1024, 'null' => true])
@@ -84,7 +84,7 @@ class EavBehaviorTest extends TestCase
             $schema = new TableSchema('eav_json');
             $schema
                 ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('entity_table', ['type' => 'string', 'length' => 191, 'null' => false])
+                ->addColumn('entity_table', ['type' => 'string', 'length' => 255, 'null' => false])
                 ->addColumn('entity_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('attribute_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('value', ['type' => 'json', 'null' => true])


### PR DESCRIPTION
#comment Generator—replace entity_table with eav_entity_id FK, rename attribute_id→eav_attribute_id, update composite unique index and FKs; align raw SQL and tests. Also fixed the field length of the varchar fields updating them from 191 to 255.