### PR TITLE
EAV-29 Composite PK

### DIFF
--- a/src/Command/EavSetupCommand.php
+++ b/src/Command/EavSetupCommand.php
@@ -523,15 +523,14 @@ class {$className} extends BaseMigration
             if (\$this->hasTable(\$spec['table'])) {
                 continue;
             }
-            \$table = \$this->table(\$spec['table'], ['id' => false, 'primary_key' => ['id']]);
+            // Composite PK across all installs (UUID or INT): (eav_entity_id, entity_id, eav_attribute_id)
+            \$table = \$this->table(\$spec['table'], ['id' => false, 'primary_key' => ['eav_entity_id', '{$entityField}', 'eav_attribute_id']]);
             \$table
-                ->addColumn('id', '{$uuidType}', ['null' => false])
                 ->addColumn('eav_entity_id', '{$uuidType}', ['null' => false])
                 ->addColumn('{$entityField}', '{$entityFieldType}', ['null' => false])
                 ->addColumn('eav_attribute_id', '{$uuidType}', ['null' => false])
                 ->addColumn('value', \$spec['valType'], array_merge(\$spec['valOptions'], ['null' => true]))
                 ->addTimestamps('created', 'modified')
-                ->addIndex(['eav_entity_id', '{$entityField}', 'eav_attribute_id'], ['unique' => true, 'name' => 'idx_' . \$spec['table'] . '_lookup'])
                 ->addForeignKey('eav_entity_id', 'eav_entities', 'id', ['delete' => 'CASCADE'])
                 ->addForeignKey('eav_attribute_id', 'eav_attributes', 'id', ['delete' => 'CASCADE'])
                 ->create();
@@ -567,7 +566,6 @@ PHP;
             $counter++;
             $base = $path . '/' . $timestamp . '_' . Inflector::underscore($name) . "_{$counter}.php";
         }
-
 
         return $base;
     }
@@ -653,7 +651,7 @@ PHP;
                 'date' => 'DATE',
                 'datetime', 'timestamp', 'datetimefractional', 'timestampfractional', 'timestamptimezone' => $isMy ? 'DATETIME' : 'TIMESTAMP',
                 'time' => 'TIME',
-                'binary' => 'BYTEA',
+                'binary' => $isMy ? 'BLOB' : 'BYTEA',
                 'uuid', 'binaryuuid', 'nativeuuid' => $isMy && $t === 'binaryuuid' ? 'BINARY(16)' : ($isMy ? 'CHAR(36)' : 'UUID'),
                 'json' => ($jsonStorage === 'jsonb' && !$isMy) ? 'JSONB' : 'JSON',
                 default => 'TEXT',
@@ -667,19 +665,18 @@ PHP;
 
         // Build list of eav_* table DDLs based on selected types
         $buildTableName = fn(string $t) => 'eav_' . strtolower($t);
+        // EAV-29: Composite PK (eav_entity_id, entity_id, eav_attribute_id); no surrogate id; no separate unique index
         $emitTable = function (string $table, string $valueType) use ($idCol, $entityIdCol, $mapVarchar, $tsCol, $isPg): string {
             $lines = [];
             $lines[] = "CREATE TABLE IF NOT EXISTS {$table} (";
-            $lines[] = "  id {$idCol} NOT NULL,";
             $lines[] = "  eav_entity_id {$idCol} NOT NULL,";
             $lines[] = "  entity_id {$entityIdCol} NOT NULL,";
             $lines[] = "  eav_attribute_id {$idCol} NOT NULL,";
             $lines[] = "  value {$valueType} NULL,";
             $lines[] = "  created {$tsCol} DEFAULT CURRENT_TIMESTAMP,";
             $lines[] = "  modified {$tsCol} DEFAULT CURRENT_TIMESTAMP,";
-            $lines[] = "  PRIMARY KEY (id)";
+            $lines[] = "  PRIMARY KEY (eav_entity_id, entity_id, eav_attribute_id)";
             $lines[] = ");";
-            $lines[] = "CREATE UNIQUE INDEX IF NOT EXISTS idx_{$table}_lookup ON {$table} (eav_entity_id, entity_id, eav_attribute_id);";
             $lines[] = "ALTER TABLE {$table} ADD CONSTRAINT fk_{$table}_eav_entity_id FOREIGN KEY (eav_entity_id) REFERENCES eav_entities(id) ON DELETE CASCADE;";
             $lines[] = "ALTER TABLE {$table} ADD CONSTRAINT fk_{$table}_eav_attribute_id FOREIGN KEY (eav_attribute_id) REFERENCES eav_attributes(id) ON DELETE CASCADE;";
             return implode("\n", $lines) . "\n";

--- a/src/Model/Behavior/EavBehavior.php
+++ b/src/Model/Behavior/EavBehavior.php
@@ -83,6 +83,9 @@ class EavBehavior extends Behavior
         'integer' => 'int',
     ];
 
+    /** @var array<string,string> Cached eav_entities.id by entityTable name */
+    protected array $eavEntityIdCache = [];
+
     /**
      * Capture mapped values from request data for later persistence.
      *
@@ -434,6 +437,7 @@ class EavBehavior extends Behavior
         $rootPk = (string)current((array)$table->getPrimaryKey());
         $entityField = $this->entityIdField();
         $entityTableName = (string)$this->getConfig('entityTable');
+        $eavEntityId = $this->resolveEavEntityId();
 
         // Early expression-tree WHERE rewriting for Tables storage BEFORE any projections/joins from select/order logic.
         // This avoids leaking attribute aliases (e.g., "color") into WHERE as base columns.
@@ -501,8 +505,8 @@ class EavBehavior extends Behavior
                         [$alias => $tableName],
                         [
                             "{$alias}.{$entityField} = {$rootAlias}.{$rootPk}",
-                            "{$alias}.entity_table" => $entityTableName,
-                            "{$alias}.attribute_id" => $attrId,
+                            "{$alias}.eav_entity_id" => $eavEntityId,
+                            "{$alias}.eav_attribute_id" => $attrId,
                         ]
                     );
                     $joinedAliases[$alias] = true;
@@ -607,14 +611,14 @@ class EavBehavior extends Behavior
             $alias = 'EAV_' . $safeAttr . '_' . $safeType;
             $tableName = 'eav_' . strtolower((string)$resolvedType);
 
-            // LEFT JOIN to preserve rows without the attribute
+            // LEFT JOIN to preserve rows without the attribute (EAV-28/29 composite keys)
             if (!isset($joinedAliases[$alias])) {
                 $query->leftJoin(
                     [$alias => $tableName],
                     [
                         "{$alias}.{$entityField} = {$rootAlias}.{$rootPk}",
-                        "{$alias}.entity_table" => $entityTableName,
-                        "{$alias}.attribute_id" => $attrId,
+                        "{$alias}.eav_entity_id" => $eavEntityId,
+                        "{$alias}.eav_attribute_id" => $attrId,
                     ]
                 );
                 $joinedAliases[$alias] = true;
@@ -739,8 +743,8 @@ class EavBehavior extends Behavior
                         [$alias => $tableName],
                         [
                             "{$alias}.{$entityField} = {$rootAlias}.{$rootPk}",
-                            "{$alias}.entity_table" => $entityTableName,
-                            "{$alias}.attribute_id" => $attrId,
+                            "{$alias}.eav_entity_id" => $eavEntityId,
+                            "{$alias}.eav_attribute_id" => $attrId,
                         ]
                     );
                     $joinedAliases[$alias] = true;
@@ -909,8 +913,8 @@ class EavBehavior extends Behavior
                                 [$alias => $tableName],
                                 [
                                     "{$alias}.{$entityField} = {$rootAlias}.{$rootPk}",
-                                    "{$alias}.entity_table" => $entityTableName,
-                                    "{$alias}.attribute_id" => $attrId,
+                                    "{$alias}.eav_entity_id" => $eavEntityId,
+                                    "{$alias}.eav_attribute_id" => $attrId,
                                 ]
                             );
                             $joinedAliases[$alias] = true;
@@ -1005,8 +1009,8 @@ class EavBehavior extends Behavior
                             [$alias => $tableName],
                             [
                                 "{$alias}.{$entityField} = {$rootAlias}.{$rootPk}",
-                                "{$alias}.entity_table" => $entityTableName,
-                                "{$alias}.attribute_id" => $attrId,
+                                "{$alias}.eav_entity_id" => $eavEntityId,
+                                "{$alias}.eav_attribute_id" => $attrId,
                             ]
                         );
                         $joinedAliases[$alias] = true;
@@ -1078,6 +1082,7 @@ class EavBehavior extends Behavior
             $rootPk = (string)current((array)$table->getPrimaryKey());
             $entityField = $this->entityIdField();
             $entityTableName = (string)$this->getConfig('entityTable');
+            $eavEntityId = $this->resolveEavEntityId();
 
             foreach ($rawConds as $key => $value) {
                 // Keep non-string keys (expressions) as-is
@@ -1183,8 +1188,8 @@ class EavBehavior extends Behavior
                         [$alias => $tableName],
                         [
                             "{$alias}.{$entityField} = {$rootAlias}.{$rootPk}",
-                            "{$alias}.entity_table" => $entityTableName,
-                            "{$alias}.attribute_id" => $attrId,
+                            "{$alias}.eav_entity_id" => $eavEntityId,
+                            "{$alias}.eav_attribute_id" => $attrId,
                         ]
                     );
                     $joinedAliases[$alias] = true;
@@ -1331,6 +1336,8 @@ class EavBehavior extends Behavior
         string $entityTableName
     ): ?QueryExpression {
         $driver = $query->getConnection()->getDriver();
+        // EAV-28/29: resolve registry FK once; use composite key in joins
+        $eavEntityId = $this->resolveEavEntityId();
 
         // Helper: resolve attribute type from overrides/map/registry/inference
         $resolveType = function (string $field, mixed $value) use ($overrideTypes, $map) {
@@ -1366,7 +1373,7 @@ class EavBehavior extends Behavior
         };
 
         // Helper: ensure a join exists for this attribute/type and return alias + whether it was left-joined
-        $ensureJoin = function (string $field, string $type, string $op, ?string &$alias, ?string &$tableName, ?string &$attrId) use (&$joinedAliases, $query, $entityField, $entityTableName, $rootAlias, $rootPk) {
+        $ensureJoin = function (string $field, string $type, string $op, ?string &$alias, ?string &$tableName, ?string &$attrId) use (&$joinedAliases, $query, $entityField, $rootAlias, $rootPk, $eavEntityId) {
             $safeAttr = preg_replace('/[^a-z0-9_]+/i', '_', strtolower($field));
             $safeType = preg_replace('/[^a-z0-9_]+/i', '_', strtolower($type));
             $alias = 'EAV_' . $safeAttr . '_' . $safeType;
@@ -1399,8 +1406,8 @@ class EavBehavior extends Behavior
                     [$alias => $tableName],
                     [
                         "{$alias}.{$entityField} = {$rootAlias}.{$rootPk}",
-                        "{$alias}.entity_table" => $entityTableName,
-                        "{$alias}.attribute_id" => $attrId,
+                        "{$alias}.eav_entity_id" => $eavEntityId,
+                        "{$alias}.eav_attribute_id" => $attrId,
                     ]
                 );
                 $joinedAliases[$alias] = true;
@@ -1862,6 +1869,9 @@ class EavBehavior extends Behavior
     /**
      * Get AV table instance for a type and storage.
      *
+     * Always returns a generic Table bound to the concrete eav_<type> table to avoid
+     * legacy validations/rules in model classes (entity_table/attribute_id) during composite-key writes.
+     *
      * @param string $type Normalized type.
      * @param string|null $storage JSON storage.
      * @return \Cake\ORM\Table
@@ -1870,11 +1880,6 @@ class EavBehavior extends Behavior
     {
         // Try canonical class first; if missing, fall back to a generic Table with explicit eav_<type> name.
         $segment = $this->tableTypeSegment($type, $storage);
-        $fqcn = 'Eav\\Model\\Table\\Eav' . $segment . 'Table';
-        if (class_exists($fqcn)) {
-            return $this->getTableLocator()->get($this->avTableClass($type, $storage));
-        }
-
         $tableName = 'eav_' . strtolower($type);
         $alias = 'EavDynamic' . $segment;
 
@@ -1901,23 +1906,33 @@ class EavBehavior extends Behavior
         $tbl = $this->tableFor($normalized['type'], $normalized['storage']);
         $value = $this->castValueForType($normalized['type'], $val);
         $entityField = $this->entityIdField();
-        $data = [
-            'entity_table' => (string)$this->getConfig('entityTable'),
-            $entityField => $entityId,
-            'attribute_id' => $attrId,
-            'value' => $value,
-        ];
+
+        // EAV-28/29: use eav_entity_id + eav_attribute_id + entity_id (composite key)
+        $eavEntityId = $this->resolveEavEntityId();
+
         $row = $tbl->find()
             ->where([
-                'entity_table' => $data['entity_table'],
-                'attribute_id' => $attrId,
+                'eav_entity_id' => $eavEntityId,
+                'eav_attribute_id' => $attrId,
                 $entityField => $entityId,
             ])
             ->first();
+
         if ($row) {
-            $tbl->patchEntity($row, ['value' => $value]);
+            $tbl->patchEntity($row, [
+                'value' => $value,
+                'modified' => DateTime::now(),
+            ]);
         } else {
-            $row = $tbl->newEntity($data);
+            $now = DateTime::now();
+            $row = $tbl->newEntity([
+                'eav_entity_id' => $eavEntityId,
+                $entityField => $entityId,
+                'eav_attribute_id' => $attrId,
+                'value' => $value,
+                'created' => $now,
+                'modified' => $now,
+            ]);
         }
         try {
             $tbl->saveOrFail($row);
@@ -1925,7 +1940,7 @@ class EavBehavior extends Behavior
             throw new RuntimeException(
                 sprintf('Failed to save EAV value for %s:%s', $attributeName, (string)$entityId),
                 0,
-                $e,
+                $e
             );
         }
     }
@@ -1952,12 +1967,13 @@ class EavBehavior extends Behavior
         $attributeIds = [];
         foreach ($byType as $normalized) {
             $tbl = $this->tableFor($normalized['type'], $normalized['storage']);
+            $eavEntityId = $this->resolveEavEntityId();
             $rows = $tbl->find()
-                ->where(['entity_table' => (string)$this->getConfig('entityTable')])
+                ->where(['eav_entity_id' => $eavEntityId])
                 ->where([$entityField . ' IN' => $ids])
                 ->all();
             foreach ($rows as $r) {
-                $attrId = (string)$r->get('attribute_id');
+                $attrId = (string)$r->get('eav_attribute_id');
                 $rawRows[] = [
                     'entity_id' => (string)$r->get($entityField),
                     'attribute_id' => $attrId,
@@ -2014,13 +2030,16 @@ class EavBehavior extends Behavior
             throw new InvalidArgumentException(sprintf('Unsupported operator "%s".', $op));
         }
 
+        // EAV-28/29: join on composite key parts (eav_entity_id, eav_attribute_id) and entity_id
+        $eavEntityId = $this->resolveEavEntityId();
+
         $query->innerJoin(
             [$alias => $table],
             [
                 "{$alias}.{$entityField} = {$root}.{$rootPk}",
-                "{$alias}.entity_table" => (string)$this->getConfig('entityTable'),
-                "{$alias}.attribute_id" => $attrId,
-            ],
+                "{$alias}.eav_entity_id" => $eavEntityId,
+                "{$alias}.eav_attribute_id" => $attrId,
+            ]
         );
 
         if ($op === 'IN') {
@@ -2233,6 +2252,60 @@ class EavBehavior extends Behavior
     protected function pkSuffix(): string
     {
         return $this->getConfig('pkType') === 'int' ? 'Int' : 'Uuid';
+    }
+
+    /**
+     * Resolve the eav_entities.id for the configured entityTable.
+     * Caches per behavior instance to avoid repeated lookups during a request.
+     *
+     * @return string UUID of the EAV entity registry row.
+     */
+    protected function resolveEavEntityId(): string
+    {
+        $entityTableName = (string)$this->getConfig('entityTable');
+        if ($entityTableName === '') {
+            throw new RuntimeException('EavBehavior: entityTable must be configured to resolve eav_entity_id.');
+        }
+
+        if (isset($this->eavEntityIdCache[$entityTableName])) {
+            return $this->eavEntityIdCache[$entityTableName];
+        }
+
+        try {
+            $Entities = $this->getTableLocator()->get('Eav.EavEntities');
+            $row = $Entities->find()
+                ->select(['id'])
+                ->where(['name' => $entityTableName])
+                ->enableHydration(false)
+                ->first();
+
+            if (!$row) {
+                // Fallback to table_name match if name isn't populated
+                $row = $Entities->find()
+                    ->select(['id'])
+                    ->where(['table_name' => $entityTableName])
+                    ->enableHydration(false)
+                    ->first();
+            }
+
+            if (!$row || !isset($row['id'])) {
+                throw new RuntimeException(sprintf(
+                    'EavBehavior: No eav_entities row found for "%s". Seed eav_entities first.',
+                    $entityTableName
+                ));
+            }
+
+            $id = (string)$row['id'];
+            $this->eavEntityIdCache[$entityTableName] = $id;
+            return $id;
+        } catch (\Throwable $e) {
+            // Surface a clear message for tests/environments missing the registry
+            throw new RuntimeException(
+                sprintf('EavBehavior: Failed to resolve eav_entity_id for "%s": %s', $entityTableName, $e->getMessage()),
+                0,
+                $e
+            );
+        }
     }
 
     /**

--- a/tests/Fixture/EavEntitiesFixture.php
+++ b/tests/Fixture/EavEntitiesFixture.php
@@ -10,6 +10,24 @@ use Cake\TestSuite\Fixture\TestFixture;
  */
 class EavEntitiesFixture extends TestFixture
 {
+    public string $table = 'eav_entities';
+
+    public array $fields = [
+        'id' => ['type' => 'uuid', 'null' => false],
+        'name' => ['type' => 'string', 'length' => 255, 'null' => false],
+        'model_alias' => ['type' => 'string', 'length' => 255, 'null' => true],
+        'table_name' => ['type' => 'string', 'length' => 255, 'null' => true],
+        'storage_default' => ['type' => 'string', 'length' => 20, 'null' => false, 'default' => 'tables'],
+        'json_column' => ['type' => 'string', 'length' => 255, 'null' => true],
+        'pk_type' => ['type' => 'string', 'length' => 10, 'null' => false, 'default' => 'uuid'],
+        'uuid_subtype' => ['type' => 'string', 'length' => 20, 'null' => true],
+        'created' => ['type' => 'datetime', 'null' => false],
+        'modified' => ['type' => 'datetime', 'null' => false],
+        '_constraints' => [
+            'primary' => ['type' => 'primary', 'columns' => ['id']],
+        ],
+    ];
+
     /**
      * Init method
      *
@@ -18,17 +36,31 @@ class EavEntitiesFixture extends TestFixture
     public function init(): void
     {
         $this->records = [
+            // Registry entry for tables using entityTable = 'test_entities'
             [
-                'id' => '19dac9a9-3cf7-4e92-9452-98782800e735',
-                'name' => 'Lorem ipsum dolor sit amet',
-                'model_alias' => 'Lorem ipsum dolor sit amet',
-                'table_name' => 'Lorem ipsum dolor sit amet',
-                'storage_default' => 'Lorem ipsum dolor ',
-                'json_column' => 'Lorem ipsum dolor sit amet',
-                'pk_type' => 'Lorem ip',
-                'uuid_subtype' => 'Lorem ipsum dolor ',
-                'created' => 1766960673,
-                'modified' => 1766960673,
+                'id' => '00000000-0000-0000-0000-000000000001',
+                'name' => 'test_entities',
+                'model_alias' => null,
+                'table_name' => 'test_entities',
+                'storage_default' => 'tables',
+                'json_column' => null,
+                'pk_type' => 'uuid',
+                'uuid_subtype' => 'uuid',
+                'created' => '2024-01-01 00:00:00',
+                'modified' => '2024-01-01 00:00:00',
+            ],
+            // Registry entry for migrator tests using entityTable = 'json_entities'
+            [
+                'id' => '00000000-0000-0000-0000-000000000002',
+                'name' => 'json_entities',
+                'model_alias' => null,
+                'table_name' => 'json_entities',
+                'storage_default' => 'tables',
+                'json_column' => null,
+                'pk_type' => 'uuid',
+                'uuid_subtype' => 'uuid',
+                'created' => '2024-01-01 00:00:00',
+                'modified' => '2024-01-01 00:00:00',
             ],
         ];
         parent::init();

--- a/tests/Fixture/EavJsonFixture.php
+++ b/tests/Fixture/EavJsonFixture.php
@@ -10,15 +10,14 @@ class EavJsonFixture extends TestFixture
     public string $table = 'eav_json';
 
     public array $fields = [
-        'id' => ['type' => 'uuid', 'null' => false],
-        'entity_table' => ['type' => 'string', 'length' => 255, 'null' => false],
+        'eav_entity_id' => ['type' => 'uuid', 'null' => false],
         'entity_id' => ['type' => 'uuid', 'null' => false],
-        'attribute_id' => ['type' => 'uuid', 'null' => false],
+        'eav_attribute_id' => ['type' => 'uuid', 'null' => false],
         'value' => ['type' => 'json', 'null' => true],
         'created' => ['type' => 'datetime', 'null' => false],
         'modified' => ['type' => 'datetime', 'null' => false],
         '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'primary' => ['type' => 'primary', 'columns' => ['eav_entity_id', 'entity_id', 'eav_attribute_id']],
         ],
     ];
 
@@ -26,10 +25,9 @@ class EavJsonFixture extends TestFixture
     {
         $this->records = [
             [
-                'id' => 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
-                'entity_table' => 'test_entities',
+                'eav_entity_id' => '00000000-0000-0000-0000-000000000001',
                 'entity_id' => '22222222-2222-2222-2222-222222222222',
-                'attribute_id' => '22222222-2222-2222-2222-222222222222',
+                'eav_attribute_id' => '22222222-2222-2222-2222-222222222222',
                 'value' => ['foo' => 'bar'],
                 'created' => '2024-01-01 00:00:00',
                 'modified' => '2024-01-01 00:00:00',

--- a/tests/Fixture/EavStringFixture.php
+++ b/tests/Fixture/EavStringFixture.php
@@ -10,15 +10,14 @@ class EavStringFixture extends TestFixture
     public string $table = 'eav_string';
 
     public array $fields = [
-        'id' => ['type' => 'uuid', 'null' => false],
-        'entity_table' => ['type' => 'string', 'length' => 255, 'null' => false],
+        'eav_entity_id' => ['type' => 'uuid', 'null' => false],
         'entity_id' => ['type' => 'uuid', 'null' => false],
-        'attribute_id' => ['type' => 'uuid', 'null' => false],
+        'eav_attribute_id' => ['type' => 'uuid', 'null' => false],
         'value' => ['type' => 'string', 'length' => 1024, 'null' => true],
         'created' => ['type' => 'datetime', 'null' => false],
         'modified' => ['type' => 'datetime', 'null' => false],
         '_constraints' => [
-            'primary' => ['type' => 'primary', 'columns' => ['id']],
+            'primary' => ['type' => 'primary', 'columns' => ['eav_entity_id', 'entity_id', 'eav_attribute_id']],
         ],
     ];
 
@@ -26,10 +25,9 @@ class EavStringFixture extends TestFixture
     {
         $this->records = [
             [
-                'id' => 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-                'entity_table' => 'test_entities',
+                'eav_entity_id' => '00000000-0000-0000-0000-000000000001',
                 'entity_id' => '22222222-2222-2222-2222-222222222222',
-                'attribute_id' => '11111111-1111-1111-1111-111111111111',
+                'eav_attribute_id' => '11111111-1111-1111-1111-111111111111',
                 'value' => 'red',
                 'created' => '2024-01-01 00:00:00',
                 'modified' => '2024-01-01 00:00:00',

--- a/tests/TestCase/Command/EavMigrateJsonbToEavCommandTest.php
+++ b/tests/TestCase/Command/EavMigrateJsonbToEavCommandTest.php
@@ -18,6 +18,7 @@ class EavMigrateJsonbToEavCommandTest extends TestCase
 
     protected array $fixtures = [
         'plugin.Eav.EavAttributes',
+        'plugin.Eav.EavEntities',
         'plugin.Eav.EavString',
         'plugin.Eav.JsonEntities',
     ];
@@ -57,14 +58,13 @@ class EavMigrateJsonbToEavCommandTest extends TestCase
         if (!in_array('eav_string', $existing, true)) {
             $schema = new TableSchema('eav_string');
             $schema
-                ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('entity_table', ['type' => 'string', 'length' => 255, 'null' => false])
+                ->addColumn('eav_entity_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('entity_id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('attribute_id', ['type' => 'uuid', 'null' => false])
+                ->addColumn('eav_attribute_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('value', ['type' => 'string', 'length' => 1024, 'null' => true])
                 ->addColumn('created', ['type' => 'datetime', 'null' => false])
                 ->addColumn('modified', ['type' => 'datetime', 'null' => false])
-                ->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+                ->addConstraint('primary', ['type' => 'primary', 'columns' => ['eav_entity_id', 'entity_id', 'eav_attribute_id']]);
             $definitions[] = $schema;
         }
 

--- a/tests/TestCase/Command/EavSetupCommandTest.php
+++ b/tests/TestCase/Command/EavSetupCommandTest.php
@@ -30,12 +30,15 @@ class EavSetupCommandTest extends TestCase
         $this->assertOutputContains("->addColumn('placeholder'");
         $this->assertOutputContains("->addColumn('help_text'");
 
-        // EAV-28: updated value tables schema
+        // EAV-29: value tables schema (composite PK, no unique index)
         $this->assertOutputContains("->addColumn('eav_entity_id'");
         $this->assertOutputContains("->addColumn('eav_attribute_id'");
         $this->assertOutputContains("->addForeignKey('eav_entity_id', 'eav_entities', 'id'");
         $this->assertOutputContains("->addForeignKey('eav_attribute_id', 'eav_attributes', 'id'");
-        $this->assertOutputContains("->addIndex(['eav_entity_id', 'entity_id', 'eav_attribute_id']");
+        // Composite primary key present
+        $this->assertOutputContains("'primary_key' => ['eav_entity_id', 'entity_id', 'eav_attribute_id']");
+        // No separate unique index on lookup columns under EAV-29
+        $this->assertOutputNotContains("->addIndex(['eav_entity_id', 'entity_id', 'eav_attribute_id']");
         $this->assertOutputNotContains("->addColumn('entity_table'");
     }
 
@@ -64,13 +67,13 @@ class EavSetupCommandTest extends TestCase
         $this->assertOutputContains('CREATE TABLE IF NOT EXISTS eav_entities');
         $this->assertOutputContains('CREATE TABLE IF NOT EXISTS eav_attribute_sets_eav_attributes');
 
-        // EAV-28: value tables DDL checks
-        $this->assertOutputContains('CREATE UNIQUE INDEX IF NOT EXISTS idx_eav_string_lookup');
-        $this->assertOutputContains('(eav_entity_id, entity_id, eav_attribute_id)');
+        // EAV-29: value tables DDL checks (composite PK; no unique index)
+        $this->assertOutputContains('PRIMARY KEY (eav_entity_id, entity_id, eav_attribute_id)');
         $this->assertOutputContains('FOREIGN KEY (eav_entity_id) REFERENCES eav_entities(id)');
         $this->assertOutputContains('FOREIGN KEY (eav_attribute_id) REFERENCES eav_attributes(id)');
         $this->assertOutputContains('eav_entity_id');
         $this->assertOutputContains('eav_attribute_id');
+        $this->assertOutputNotContains('CREATE UNIQUE INDEX IF NOT EXISTS idx_eav_string_lookup');
         $this->assertOutputNotContains('entity_table');
     }
 

--- a/tests/TestCase/Model/Behavior/EavBehaviorTest.php
+++ b/tests/TestCase/Model/Behavior/EavBehaviorTest.php
@@ -40,6 +40,7 @@ class EavBehaviorTest extends TestCase
 {
     protected array $fixtures = [
         'plugin.Eav.EavAttributes',
+        'plugin.Eav.EavEntities',
         'plugin.Eav.EavString',
         'plugin.Eav.EavJson',
     ];
@@ -69,28 +70,26 @@ class EavBehaviorTest extends TestCase
         if (!in_array('eav_string', $existing, true)) {
             $schema = new TableSchema('eav_string');
             $schema
-                ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('entity_table', ['type' => 'string', 'length' => 255, 'null' => false])
+                ->addColumn('eav_entity_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('entity_id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('attribute_id', ['type' => 'uuid', 'null' => false])
+                ->addColumn('eav_attribute_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('value', ['type' => 'string', 'length' => 1024, 'null' => true])
                 ->addColumn('created', ['type' => 'datetime', 'null' => false])
                 ->addColumn('modified', ['type' => 'datetime', 'null' => false])
-                ->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+                ->addConstraint('primary', ['type' => 'primary', 'columns' => ['eav_entity_id', 'entity_id', 'eav_attribute_id']]);
             $definitions[] = $schema;
         }
 
         if (!in_array('eav_json', $existing, true)) {
             $schema = new TableSchema('eav_json');
             $schema
-                ->addColumn('id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('entity_table', ['type' => 'string', 'length' => 255, 'null' => false])
+                ->addColumn('eav_entity_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('entity_id', ['type' => 'uuid', 'null' => false])
-                ->addColumn('attribute_id', ['type' => 'uuid', 'null' => false])
+                ->addColumn('eav_attribute_id', ['type' => 'uuid', 'null' => false])
                 ->addColumn('value', ['type' => 'json', 'null' => true])
                 ->addColumn('created', ['type' => 'datetime', 'null' => false])
                 ->addColumn('modified', ['type' => 'datetime', 'null' => false])
-                ->addConstraint('primary', ['type' => 'primary', 'columns' => ['id']]);
+                ->addConstraint('primary', ['type' => 'primary', 'columns' => ['eav_entity_id', 'entity_id', 'eav_attribute_id']]);
             $definitions[] = $schema;
         }
 

--- a/tests/TestCase/Model/Behavior/EavTablesStorageModeTest.php
+++ b/tests/TestCase/Model/Behavior/EavTablesStorageModeTest.php
@@ -15,8 +15,9 @@ class EavTablesStorageModeTest extends TestCase
 {
     protected array $fixtures = [
         'plugin.Eav.EavAttributes',
+        'plugin.Eav.EavEntities',
         'plugin.Eav.EavString',
-        'plugin.Eav.TestEntities',
+        'plugin.Eav.EavJson',
     ];
 
     public static function setUpBeforeClass(): void
@@ -51,6 +52,13 @@ class EavTablesStorageModeTest extends TestCase
             'table' => 'test_entities',
         ]);
         $this->Entities->setPrimaryKey('id');
+
+        // Seed base rows so EAV joins have left-side entities to match
+        $conn = \Cake\Datasource\ConnectionManager::get('test');
+        // Truncate to ensure deterministic content across tests
+        $conn->execute('TRUNCATE test_entities');
+        $conn->execute("INSERT INTO test_entities (id) VALUES ('22222222-2222-2222-2222-222222222222')");
+        $conn->execute("INSERT INTO test_entities (id) VALUES ('33333333-3333-3333-3333-333333333333')");
 
         // Attach behavior in tables storage mode; no explicit map required for rewriting
         $this->Entities->addBehavior('Eav.Eav', [
@@ -127,9 +135,9 @@ class EavTablesStorageModeTest extends TestCase
         $EavString = TableRegistry::getTableLocator()->get('Eav.EavString');
         $row = $EavString->find()
             ->where([
-                'entity_table' => 'test_entities',
+                'eav_entity_id' => '00000000-0000-0000-0000-000000000001', // test_entities
                 'entity_id' => $newId,
-                'attribute_id' => $colorAttr['id'],
+                'eav_attribute_id' => $colorAttr['id'],
             ])
             ->first();
 


### PR DESCRIPTION
#comment feat(eav): standardize composite PK for EAV value tables; remove surrogate id and unique index
         Update generators (migrations/raw SQL) to emit PRIMARY KEY (eav_entity_id, entity_id, eav_attribute_id) with FKs and no unique lookup index. Align fixtures and tests to composite schema. Update behavior (tables storage) to use eav_entity_id/eav_attribute_id for joins/reads/writes; add eav_entity resolver and ensure timestamps on dynamic inserts. All tests passing.